### PR TITLE
[#2] 로그인 API 및 JWT API 인가 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### properties ###
+!**/src/main/resources/application.properties

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,35 @@ repositories {
 }
 
 dependencies {
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	compileOnly 'org.projectlombok:lombok'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+	implementation group: 'mysql', name: 'mysql-connector-java', version: '8.0.33'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	//swagger
+	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+
+
+	implementation 'org.json:json:20230227'
+
+	//jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.1'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.1'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.1'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+
+	//h2 db
+	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/kakao_clone/feature/user/application/UserService.java
+++ b/src/main/java/com/example/kakao_clone/feature/user/application/UserService.java
@@ -1,12 +1,49 @@
 package com.example.kakao_clone.feature.user.application;
 
+import com.example.kakao_clone.feature.user.domain.User;
 import com.example.kakao_clone.feature.user.domain.repository.UserRepository;
+import com.example.kakao_clone.global.auth.domain.Role;
+import com.example.kakao_clone.global.auth.presentation.request.SignupRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
+    @Autowired
     private final UserRepository userRepository;
+
+
+    public void register(SignupRequest signupRequest) {
+        validateDuplicateUser(signupRequest.getUserId());
+
+        User user = User.builder()
+                .role(Role.USER)
+                .userId(signupRequest.getUserId())
+                .password(signupRequest.getPassword())
+                .name(signupRequest.getName())
+                .statusMessage(signupRequest.getStatusMessage())
+                .profileImageUrl("")
+                .backgroundImageUrl("")
+                .lastLoginDate(LocalDateTime.now())
+                .build();
+
+        userRepository.save(user);
+    }
+
+    @Transactional
+    private void validateDuplicateUser(String userid){
+        Optional<User> userModel = userRepository.findByUserId(userid);
+        if (userModel.isPresent()) {
+            throw new IllegalStateException("이미 존재하는 회원입니다.");
+        }
+    }
 }

--- a/src/main/java/com/example/kakao_clone/feature/user/domain/User.java
+++ b/src/main/java/com/example/kakao_clone/feature/user/domain/User.java
@@ -1,23 +1,28 @@
 package com.example.kakao_clone.feature.user.domain;
 
-import com.example.kakao_clone.feature.chat.domain.Chat;
+//import com.example.kakao_clone.feature.chat.domain.Chat;
+//import com.example.kakao_clone.feature.friend.domain.Friend;
+import com.example.kakao_clone.global.auth.domain.Role;
 import com.example.kakao_clone.global.common.BaseEntity;
-import com.example.kakao_clone.feature.friend.domain.Friend;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "users")
 public class User extends BaseEntity {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private Role role;
 
     private String userId;
 
@@ -29,11 +34,13 @@ public class User extends BaseEntity {
 
     private String profileImageUrl;
 
+    private String backgroundImageUrl;
+
     private LocalDateTime lastLoginDate;
 
-    @OneToMany(mappedBy = "user")
-    private List<Chat> chatList = new ArrayList<>();
-
-    @OneToMany(mappedBy = "user")
-    private List<Friend> friendList = new ArrayList<>();
+//    @OneToMany(mappedBy = "user")
+//    private List<Chat> chatList = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "user")
+//    private List<Friend> friendList = new ArrayList<>();
 }

--- a/src/main/java/com/example/kakao_clone/feature/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/example/kakao_clone/feature/user/domain/repository/UserRepository.java
@@ -4,6 +4,9 @@ import com.example.kakao_clone.feature.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUserId(String userId);
 }

--- a/src/main/java/com/example/kakao_clone/global/auth/Role.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/Role.java
@@ -1,0 +1,15 @@
+package com.example.kakao_clone.global.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+    ADMIN("ROLE_ADMIN", "관리자"),
+    USER("ROLE_USER", "일반 사용자");
+
+    private final String key;
+    private final String title;
+
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/application/AuthService.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/application/AuthService.java
@@ -1,4 +1,129 @@
 package com.example.kakao_clone.global.auth.application;
 
+import com.example.kakao_clone.feature.user.domain.User;
+import com.example.kakao_clone.feature.user.domain.repository.UserRepository;
+import com.example.kakao_clone.global.auth.jwt.JwtTokenProvider;
+import com.example.kakao_clone.global.auth.presentation.request.LoginRequest;
+import com.example.kakao_clone.global.auth.presentation.response.TokenResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class AuthService {
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+    private final RedisService redisService;
+    private final String SERVER = "Server";
+
+    @Transactional
+    public TokenResponse login(LoginRequest loginRequest) {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        User user = userRepository.findByUserId(loginRequest.getUserId()).orElseThrow(()->{
+            throw new IllegalStateException("ID를 다시 확인하세요.");
+        });
+
+        UsernamePasswordAuthenticationToken authenticationToken =
+                new UsernamePasswordAuthenticationToken(loginRequest.getUserId(), loginRequest.getPassword());
+
+        Authentication authentication = authenticationManagerBuilder.getObject()
+                .authenticate(authenticationToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return generateToken(SERVER, authentication.getName(), getAuthorities(authentication));
+    }
+
+    public boolean validate(String requestAccessTokenInHeader) {
+        String requestAccessToken = resolveToken(requestAccessTokenInHeader);
+        return jwtTokenProvider.validateAccessTokenOnlyExpired(requestAccessToken);
+    }
+
+    @Transactional
+    public TokenResponse reissue(String requestAccessTokenInHeader, String requestRefreshToken) {
+        String requestAccessToken = resolveToken(requestAccessTokenInHeader);
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(requestAccessToken);
+        String principal = getPrincipal(requestAccessToken);
+
+        String refreshTokenInRedis = redisService.getValues("RT(" + SERVER + "):" + principal);
+        if (refreshTokenInRedis == null) {
+            return null;
+        }
+
+        if(!jwtTokenProvider.validateRefreshToken(requestRefreshToken) || !refreshTokenInRedis.equals(requestRefreshToken)) {
+            redisService.deleteValues("RT(" + SERVER + "):" + principal);
+            return null;
+        }
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        String authorities = getAuthorities(authentication);
+
+        redisService.deleteValues("RT(" + SERVER + "):" + principal);
+        TokenResponse tokenResponse = jwtTokenProvider.createToken(principal, authorities);
+        saveRefreshToken(SERVER, principal, tokenResponse.getRefreshToken());
+        return tokenResponse;
+    }
+
+    @Transactional
+    public TokenResponse generateToken(String provider, String email, String authorities) {
+        if(redisService.getValues("RT(" + provider + "):" + email) != null) {
+            redisService.deleteValues("RT(" + provider + "):" + email);
+        }
+
+        TokenResponse tokenResponse = jwtTokenProvider.createToken(email, authorities);
+        saveRefreshToken(provider, email, tokenResponse.getRefreshToken());
+        return tokenResponse;
+    }
+
+    @Transactional
+    public void saveRefreshToken(String provider, String principal, String refreshToken) {
+        redisService.setValuesWithTimeout("RT(" + provider + "):" + principal, refreshToken, jwtTokenProvider.getTokenExpirationTime(refreshToken));
+    }
+
+    public String getAuthorities(Authentication authentication) {
+        return authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+    }
+
+    public String getPrincipal(String requestAccessToken) {
+        return jwtTokenProvider.getAuthentication(requestAccessToken).getName();
+    }
+
+    public String resolveToken(String requestAccessTokenInHeader) {
+        if (requestAccessTokenInHeader != null && requestAccessTokenInHeader.startsWith("Bearer ")) {
+            return requestAccessTokenInHeader.substring(7);
+        }
+        return null;
+    }
+
+    @Transactional
+    public void logout(String requestAccessTokenInHeader) {
+        String requestAccessToken = resolveToken(requestAccessTokenInHeader);
+        String principal = getPrincipal(requestAccessToken);
+
+        String refreshTokenInRedis = redisService.getValues("RT(" + SERVER + "):" + principal);
+        if (refreshTokenInRedis != null) {
+            redisService.deleteValues("RT(" + SERVER + "):" + principal);
+        }
+
+        long expiration = jwtTokenProvider.getTokenExpirationTime(requestAccessToken) - new Date().getTime();
+        redisService.setValuesWithTimeout(requestAccessToken,
+                "logout",
+                expiration);
+    }
 }

--- a/src/main/java/com/example/kakao_clone/global/auth/application/RedisService.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/application/RedisService.java
@@ -1,0 +1,32 @@
+package com.example.kakao_clone.global.auth.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Transactional
+    public void setValues(String key, String value) {redisTemplate.opsForValue().set(key, value);}
+
+    @Transactional
+    public void setValuesWithTimeout(String key, String value, long timeout){
+        redisTemplate.opsForValue().set(key, value, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public String getValues(String key){
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    @Transactional
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/application/UserDetailsImpl.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/application/UserDetailsImpl.java
@@ -1,0 +1,55 @@
+package com.example.kakao_clone.global.auth.application;
+
+import com.example.kakao_clone.feature.user.domain.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+    private final User user;
+
+    public UserDetailsImpl(User user){
+        this.user = user;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(() -> user.getRole().getKey());
+        return authorities;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUserId();
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/application/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/application/UserDetailsServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.kakao_clone.global.auth.application;
+
+import com.example.kakao_clone.feature.user.domain.User;
+import com.example.kakao_clone.feature.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetailsImpl loadUserByUsername(String userId) throws UsernameNotFoundException {
+        User findUser = userRepository.findByUserId(userId)
+                .orElseThrow(() -> new UsernameNotFoundException("해당 아이디로 찾을 수 없습니다. -> " + userId));
+
+        return new UserDetailsImpl(findUser);
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/domain/Role.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/domain/Role.java
@@ -1,4 +1,4 @@
-package com.example.kakao_clone.global.auth;
+package com.example.kakao_clone.global.auth.domain;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/kakao_clone/global/auth/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,24 @@
+package com.example.kakao_clone.global.auth.jwt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException {
+
+        response.setCharacterEncoding("utf-8");
+        response.sendError(403, "권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package com.example.kakao_clone.global.auth.jwt;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setCharacterEncoding("utf-8");
+        response.sendError(401, "잘못된 접근입니다.");
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,50 @@
+package com.example.kakao_clone.global.auth.jwt;
+
+import io.jsonwebtoken.IncorrectClaimException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = resolveToken(request);
+
+        try {
+            if (accessToken != null && jwtTokenProvider.validateAccessToken(accessToken)) {
+                Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (IncorrectClaimException | UsernameNotFoundException e) {
+            SecurityContextHolder.clearContext();
+            response.sendError(403);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    public String resolveToken(HttpServletRequest httpServletRequest) {
+        String bearerToken = httpServletRequest.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/jwt/JwtTokenProvider.java
@@ -1,0 +1,170 @@
+package com.example.kakao_clone.global.auth.jwt;
+
+import com.example.kakao_clone.feature.user.application.UserService;
+import com.example.kakao_clone.global.auth.application.UserDetailsImpl;
+import com.example.kakao_clone.global.auth.application.UserDetailsServiceImpl;
+import com.example.kakao_clone.global.auth.application.RedisService;
+import com.example.kakao_clone.global.auth.presentation.response.TokenResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
+@Component
+@Transactional(readOnly = true)
+public class JwtTokenProvider implements InitializingBean {
+    private final UserDetailsServiceImpl userDetailsService;
+    private final UserService userService;
+    private final RedisService redisService;
+
+    private static final String AUTHORITIES_KEY = "role";
+    private static final String ID_KEY = "userid";
+
+    private static final String url = "https://localhost:8080";
+
+    private final String secretKey;
+    private static Key signingKey;
+
+    private final Long accessTokenValidityInMilliseconds;
+    private final Long refreshTokenValidityInMilliseconds;
+
+    public JwtTokenProvider(
+            UserDetailsServiceImpl userDetailsService,
+            UserService userService, RedisService redisService,
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-validity-in-seconds}") Long accessTokenValidityInMilliseconds,
+            @Value("${jwt.refresh-token-validity-in-seconds}") Long refreshTokenValidityInMilliseconds) {
+        this.userDetailsService = userDetailsService;
+        this.userService = userService;
+        this.redisService = redisService;
+        this.secretKey = secretKey;
+        this.accessTokenValidityInMilliseconds = accessTokenValidityInMilliseconds * 1000;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidityInMilliseconds * 1000;
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        byte[] secretKeyBytes = Decoders.BASE64.decode(secretKey);
+        signingKey = Keys.hmacShaKeyFor(secretKeyBytes);
+    }
+
+    @Transactional
+    public TokenResponse createToken(String userid, String authorities){
+        Long now = System.currentTimeMillis();
+
+
+        String accessToken = Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setHeaderParam("alg", "HS512")
+                .setExpiration(new Date(now + accessTokenValidityInMilliseconds))
+                .setSubject("access-token")
+                .claim(url, true)
+                .claim(ID_KEY, userid)
+                .claim(AUTHORITIES_KEY, authorities)
+                .signWith(signingKey, SignatureAlgorithm.HS512)
+                .compact();
+
+
+        String refreshToken = Jwts.builder()
+                .setHeaderParam("typ", "JWT")
+                .setHeaderParam("alg", "HS512")
+                .setExpiration(new Date(now + refreshTokenValidityInMilliseconds))
+                .setSubject("refresh-token")
+                .signWith(signingKey, SignatureAlgorithm.HS512)
+                .compact();
+
+        return new TokenResponse(accessToken, refreshToken, "Bearer", accessTokenValidityInMilliseconds);
+    }
+
+    public Claims getClaims(String token) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(signingKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        String id = getClaims(token).get(ID_KEY).toString();
+        UserDetailsImpl userDetailsImpl = userDetailsService.loadUserByUsername(id);
+        return new UsernamePasswordAuthenticationToken(userDetailsImpl, "", userDetailsImpl.getAuthorities());
+    }
+
+    public long getTokenExpirationTime(String token) {
+        return getClaims(token).getExpiration().getTime();
+    }
+
+    public boolean validateRefreshToken(String refreshToken){
+        try {
+            if (redisService.getValues(refreshToken).equals("delete")) {
+                return false;
+            }
+            Jwts.parserBuilder()
+                    .setSigningKey(signingKey)
+                    .build()
+                    .parseClaimsJws(refreshToken);
+            return true;
+        } catch (SignatureException e) {
+            log.error("Invalid JWT signature.");
+        } catch (MalformedJwtException e) {
+            log.error("Invalid JWT token.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims string is empty.");
+        } catch (NullPointerException e){
+            log.error("JWT Token is empty.");
+        }
+        return false;
+    }
+
+    public boolean validateAccessToken(String accessToken) {
+        try {
+            if (redisService.getValues(accessToken) != null
+                    && redisService.getValues(accessToken).equals("logout")) {
+                return false;
+            }
+            Jwts.parserBuilder()
+                    .setSigningKey(signingKey)
+                    .build()
+                    .parseClaimsJws(accessToken);
+            return true;
+        } catch(ExpiredJwtException e) {
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public boolean validateAccessTokenOnlyExpired(String accessToken) {
+        try {
+            return getClaims(accessToken)
+                    .getExpiration()
+                    .before(new Date());
+        } catch(ExpiredJwtException e) {
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/presentation/AuthController.java
@@ -91,7 +91,7 @@ public class AuthController {
         }
     }
 
-    @PostMapping("/logout")
+    @DeleteMapping("/logout")
     public ResponseEntity<?> logout(@RequestHeader("Authorization") String requestAccessToken) {
         authService.logout(requestAccessToken);
         ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")

--- a/src/main/java/com/example/kakao_clone/global/auth/presentation/AuthController.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/presentation/AuthController.java
@@ -1,4 +1,107 @@
 package com.example.kakao_clone.global.auth.presentation;
 
+
+import com.example.kakao_clone.feature.user.application.UserService;
+import com.example.kakao_clone.global.auth.application.AuthService;
+import com.example.kakao_clone.global.auth.presentation.request.LoginRequest;
+import com.example.kakao_clone.global.auth.presentation.request.SignupRequest;
+import com.example.kakao_clone.global.auth.presentation.response.TokenResponse;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.*;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
+    private final UserService userService;
+    private final AuthService authService;
+    private final BCryptPasswordEncoder encoder;
+    private final long COOKIE_EXPIRATION = 86400;
+
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@RequestBody @Valid SignupRequest signupRequest) {
+        String encodedPassword = encoder.encode(signupRequest.getPassword());
+        SignupRequest newSignupRequest = SignupRequest.encodePassword(signupRequest, encodedPassword);
+        userService.register(newSignupRequest);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody @Valid LoginRequest loginRequest) {
+        TokenResponse tokenResponse = authService.login(loginRequest);
+
+        HttpCookie httpCookie = ResponseCookie.from("refresh-token", tokenResponse.getRefreshToken())
+                .maxAge(COOKIE_EXPIRATION)
+                .httpOnly(true)
+                .secure(true)
+                .build();
+        System.out.println("tokenDto.getAccessToken() = " + tokenResponse.getAccessToken());
+        System.out.println("tokenDto.getRefreshToken = " + tokenResponse.getRefreshToken());
+        System.out.println("tokenDto.getGrantType() = " + tokenResponse.getGrantType());
+        System.out.println("tokenDto.getExpiresIn() = " + tokenResponse.getExpiresIn());
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, httpCookie.toString())
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokenResponse.getAccessToken())
+                .build();
+    }
+
+    @PostMapping("/validate")
+    public ResponseEntity<?> validate(@RequestHeader("Authorization") String requestAccessToken) {
+        if (!authService.validate(requestAccessToken)) {
+            return ResponseEntity.status(HttpStatus.OK).build();
+        } else {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(@CookieValue(name = "refresh-token") String requestRefreshToken,
+                                     @RequestHeader("Authorization") String requestAccessToken) {
+        TokenResponse reissuedTokenResponse = authService.reissue(requestAccessToken, requestRefreshToken);
+
+        if (reissuedTokenResponse != null) {
+            System.out.println("재발급 성공");
+            // RT 저장
+            ResponseCookie responseCookie = ResponseCookie.from("refresh-token", reissuedTokenResponse.getRefreshToken())
+                    .maxAge(COOKIE_EXPIRATION)
+                    .httpOnly(true)
+                    .secure(true)
+                    .build();
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + reissuedTokenResponse.getAccessToken())
+                    .build();
+        } else {
+            System.out.println("재발급 실패");
+            ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
+                    .maxAge(0)
+                    .path("/")
+                    .build();
+            return ResponseEntity
+                    .status(HttpStatus.UNAUTHORIZED)
+                    .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                    .build();
+        }
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(@RequestHeader("Authorization") String requestAccessToken) {
+        authService.logout(requestAccessToken);
+        ResponseCookie responseCookie = ResponseCookie.from("refresh-token", "")
+                .maxAge(0)
+                .path("/")
+                .build();
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .build();
+    }
 }

--- a/src/main/java/com/example/kakao_clone/global/auth/presentation/request/LoginRequest.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/presentation/request/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.example.kakao_clone.global.auth.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class LoginRequest {
+    @Schema(description = "아이디", example = "userId")
+    private String userId;
+
+    @Schema(description = "password", example = "password")
+    private String password;
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/presentation/request/SignupRequest.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/presentation/request/SignupRequest.java
@@ -1,0 +1,38 @@
+package com.example.kakao_clone.global.auth.presentation.request;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SignupRequest {
+    private String userId;
+
+    private String password;
+
+    private String name;
+
+    private String statusMessage;
+
+    private String profileImageUrl;
+
+    private String backgroundImageUrl;
+
+    private LocalDateTime lastLoginDate;
+
+    @Builder
+    public static SignupRequest encodePassword(SignupRequest signupRequest, String encodedPassword) {
+        return SignupRequest.builder()
+                .userId(signupRequest.getUserId())
+                .password(encodedPassword)
+                .name(signupRequest.getName())
+                .statusMessage(signupRequest.getStatusMessage())
+                .profileImageUrl(signupRequest.getProfileImageUrl())
+                .backgroundImageUrl(signupRequest.getBackgroundImageUrl())
+                .lastLoginDate(signupRequest.getLastLoginDate())
+                .build();
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/auth/presentation/response/TokenResponse.java
+++ b/src/main/java/com/example/kakao_clone/global/auth/presentation/response/TokenResponse.java
@@ -1,0 +1,20 @@
+package com.example.kakao_clone.global.auth.presentation.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TokenResponse {
+    private String accessToken;
+
+    private String refreshToken;
+
+    private String grantType;
+
+    private Long expiresIn;
+}

--- a/src/main/java/com/example/kakao_clone/global/config/CorsConfig.java
+++ b/src/main/java/com/example/kakao_clone/global/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package com.example.kakao_clone.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("*")
+                .allowedMethods(
+                        HttpMethod.GET.name(),
+                        HttpMethod.POST.name(),
+                        HttpMethod.PUT.name(),
+                        HttpMethod.PATCH.name(),
+                        HttpMethod.DELETE.name(),
+                        HttpMethod.OPTIONS.name())
+                .maxAge(3600);
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/config/RedisConfig.java
+++ b/src/main/java/com/example/kakao_clone/global/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.example.kakao_clone.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+@RequiredArgsConstructor
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/kakao_clone/global/config/SecurityConfig.java
@@ -1,0 +1,52 @@
+package com.example.kakao_clone.global.config;
+
+import com.example.kakao_clone.global.auth.jwt.JwtAccessDeniedHandler;
+import com.example.kakao_clone.global.auth.jwt.JwtAuthenticationEntryPoint;
+import com.example.kakao_clone.global.auth.jwt.JwtAuthenticationFilter;
+import com.example.kakao_clone.global.auth.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@ComponentScan(basePackages = {"com.example.kakao_clone.global.config", "com.example.kakao_clone.auth"})
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+
+    @Bean
+    public BCryptPasswordEncoder encoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .headers(headers -> headers.frameOptions(options -> options.sameOrigin()))
+                .exceptionHandling(request -> request
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .authorizeRequests(authorizeRequests -> authorizeRequests
+                        .antMatchers("/").permitAll()
+                        .antMatchers("/swagger-ui/**", "/api-docs/**", "/api/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .build();
+    }
+}

--- a/src/main/java/com/example/kakao_clone/global/util/RedisUtil.java
+++ b/src/main/java/com/example/kakao_clone/global/util/RedisUtil.java
@@ -1,0 +1,40 @@
+package com.example.kakao_clone.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, Object> redisBlackListTemplate;
+
+    public void set(String key, Object value) {
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.opsForValue().set(key, value);
+    }
+
+    public Object get(String key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean delete(String key) {
+        return Boolean.TRUE.equals(redisTemplate.delete(key));
+    }
+
+    public boolean hasKey(String key){
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    public void setBlackList(String key, Object value) {
+        redisBlackListTemplate.setValueSerializer(new StringRedisSerializer());
+        redisBlackListTemplate.opsForValue().set(key, value);
+    }
+
+    public boolean isOnBlackList(String key) {
+        return Boolean.TRUE.equals(redisBlackListTemplate.hasKey(key));
+    }
+}


### PR DESCRIPTION
## 📌 구현
* 회원가입
* 로그인
* 유효한 토큰인지 검증
* 토큰 재발급
* 로그아웃

</br>

## 📝 상세 설명
1. 회원가입`POST /api/auth/login`
아이디를 통해 중복된 유저인지 검사하고, 아닐 경우 DB에 저장

2. 로그인 `POST /api/auth/login`
전달받은 정보를 바탕으로 데이터베이스에 저장된 사용자인지 조회
유효한 사용자일 경우, 스프링 시큐리티를 활용해 사용자의 인증 정보를 설정 후 해당 정보를 활용해 새로운 접근 토큰을 생성 및 반환 

3. 토큰 검증 `POST /api/auth/validate`
Authorization헤더에 엑세스 토큰을 전달하면, 해당 토큰이 유효한지 검사

4. 토큰 재발급 `POST /api/auth/reissue`
리프레시 토큰을 전달하면, 사용자의 토큰이 맞는지 검증하고 새로운 액세스 토큰과 리프레시 토큰을 발급하여 응답

5. 로그아웃 `DELETE /api/auth/logout`
Redis에서 해당 계정의 리프레시 토큰을 조회한 후 "logout"값과 함께 저장
